### PR TITLE
'akamai' should be a namespace package

### DIFF
--- a/akamai/__init__.py
+++ b/akamai/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     author='Jonathan Landis',
     author_email='jlandis@akamai.com',
     url='https://github.com/akamai-open/AkamaiOPEN-edgegrid-python',
+    namespace_packages=['akamai'],
     packages=find_packages(),
     install_requires = [
         'requests>=1.2.2'


### PR DESCRIPTION
This makes 'akamai' into a namespace package.  This allows there to be multiple subnames (such as edgegrid) under akamai, that aren't in the same package/egg.

See https://pythonhosted.org/setuptools/setuptools.html#namespace-packages for information.
