### PR TITLE
This change should pick up the Host value from updated headers for 'Data to Sign'.

### DIFF
--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -140,10 +140,16 @@ class EdgeGridAuth(AuthBase):
             url = r.url
 
         parsed_url = urlparse(url)
+
+        if (r.headers.get('Host', False)):
+            netloc = r.headers['Host']
+        else:
+            netloc = parsed_url.netloc
+
         data_to_sign = '\t'.join([
             r.method,
             parsed_url.scheme,
-            parsed_url.netloc,
+            netloc,
             # Note: relative URL constraints are handled by requests when it sets up 'r'
             parsed_url.path + ('?' + parsed_url.query if parsed_url.query else ""),
             self.canonicalize_headers(r),


### PR DESCRIPTION
This change should pick up the Host value from updated headers for 'Data to Sign'. This change will also supports Akamai QA environment.

for Example:

```
s = requests.Session()
s.headers.update({'Host': 'akaa-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'})
s.auth = EdgeGridAuth(...)
```

Since, Akamai QA environment requires us to update the host value in header, this module will pick up the updated host value for 'Data to Sign' to avoid Invalid signature error.
