### PR TITLE
Remove unnecessary shebangs and permissions

### DIFF
--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # EdgeGrid requests Auth handler
 #
 # Original author: Jonathan Landis <jlandis@akamai.com>

--- a/akamai/edgegrid/edgerc.py
+++ b/akamai/edgegrid/edgerc.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # support for .edgerc file format
 #
 # Copyright 2014 Akamai Technologies, Inc. All Rights Reserved


### PR DESCRIPTION
These modules aren't designed to be runnable, so the shebang
and executable bit shouldn't be here.

The motivation for this cleanup is that packaging guidelines for
distros (e.g. Fedora) consider the usage of "/usr/bin/env python"
undesirable. Since it's not doing anything here, it can simply be
removed.