### PR TITLE
Fix #41: Set minimum pyOpenSSL version to 17.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.3.0
-pyopenssl
+pyopenssl>=17.0.0
 ndg-httpsclient
 pyasn1
 urllib3


### PR DESCRIPTION
Mac OSX includes pyOpenSSL 0.13.1, which is too old to actually use this
library with Python < 3. The requirement is not specific enough to
address this problem, so this patch simply sets a more reasonable
minimum version.

Mac OSX users will need to upgrade their local version of pyOpenSSL to
use edgegrid-python or egcurl. Here is the relevant command:

pip install -U pyOpenSSL