### PR TITLE
Adds support for python3 in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,10 @@ Alternatively, your program can read the credentials from an .edgerc file.
     >>> import requests
     >>> from akamai.edgegrid import EdgeGridAuth, EdgeRc
     >>> from urlparse import urljoin
+    >>> from pathlib import Path
 
-    >>> edgerc = EdgeRc('~/.edgerc')
+    >>> edgerc_location = '{}/.edgerc'.format(str(Path.home()))
+    >>> edgerc = EdgeRc(edgerc_location)
     >>> section = 'default'
     >>> baseurl = 'https://%s' % edgerc.get(section, 'host')
 


### PR DESCRIPTION
Need to expand `~./edgerc` for this to work, at least in python3.8 on MacOS. Here was the error I was getting beforehand 
```
Traceback (most recent call last):
  File "clone_properties.py", line 6, in <module>
    baseurl = 'https://%s' % edgerc.get(section, 'host')
  File "/Users/nash.luffman/.pyenv/versions/3.7.3/lib/python3.7/configparser.py", line 780, in get
    d = self._unify_values(section, vars)
  File "/Users/nash.luffman/.pyenv/versions/3.7.3/lib/python3.7/configparser.py", line 1146, in _unify_values
    raise NoSectionError(section) from None
configparser.NoSectionError: No section: 'papi'
```
Which is quite misleading because it was never finding my edgerc file in my home directory. Using `pathlib` is the suggested way in python3.5+ to get the home directory.