### PR TITLE
Expand ~ in edgerc filename

### DIFF
--- a/akamai/edgegrid/edgerc.py
+++ b/akamai/edgegrid/edgerc.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+import os
 
 if sys.version_info[0] >= 3:
     # python3
@@ -32,6 +33,8 @@ logger = logging.getLogger(__name__)
 class EdgeRc(ConfigParser):
     def __init__(self, filename):
         ConfigParser.__init__(self, {'client_token': '', 'client_secret':'', 'host':'', 'access_token':'','max_body': '131072', 'headers_to_sign': 'None'})
+        if "~" in filename and os.name == 'nt':
+            filename = os.path.expanduser(filename)
         logger.debug("loading edgerc from %s", filename)
 
         self.read(filename)

--- a/akamai/edgegrid/edgerc.py
+++ b/akamai/edgegrid/edgerc.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class EdgeRc(ConfigParser):
     def __init__(self, filename):
         ConfigParser.__init__(self, {'client_token': '', 'client_secret':'', 'host':'', 'access_token':'','max_body': '131072', 'headers_to_sign': 'None'})
-        if "~" in filename and os.name == 'nt':
+        if "~" in filename:
             filename = os.path.expanduser(filename)
         logger.debug("loading edgerc from %s", filename)
 


### PR DESCRIPTION
Filename expansion does not seem to function on Windows, MacOS or Linux. This change makes it explicit.