### PR TITLE
Include path params in signed path

### DIFF
--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -198,7 +198,7 @@ class EdgeGridAuth(AuthBase):
             parsed_url.scheme,
             netloc,
             # Note: relative URL constraints are handled by requests when it sets up 'r'
-            parsed_url.path + ('?' + parsed_url.query if parsed_url.query else ""),
+            parsed_url.path + (';' + parsed_url.params if parsed_url.params else "") + ('?' + parsed_url.query if parsed_url.query else ""),
             self.canonicalize_headers(r),
             self.make_content_hash(r),
             auth_header


### PR DESCRIPTION
This pull request fixes #51.

Python's implementation of urlparse takes the semicolon ";" as a separator for the params section, so any string following ";" is not considered part of the path.
For this reason, urls for multi-configId SIEM fetch events requests, which by specifications should be listed in the path separated by semicolons, are not correctly signed by this library.

I.e:

`urlparse("https://***.akamaiapis.net/siem/v1/configs/111;222;333?from=1611249319&limit=200000")`

would produce:

`{ ...,
  path: "/siem/v1/configs/111",
  params: "222;333",
  query: "from=1611249319&limit=200000"
}`

Including only the path and query sections in the data_to_sign only signs _"siem/v1/configs/111?from=1611249319&limit=200000"_ and does not produce the correct signature.
Including the params section produces a correct signature which is accepted by the SIEM api.