### PR TITLE
Update license information in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,8 @@ setup(
         'pyasn1',
         'urllib3'
     ],
-    license='LICENSE.txt'
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+    ]
+    license='Apache 2.0'
 )


### PR DESCRIPTION
The `license` argument for `setuptools.setup` is a short string that specifies the "license for the package."[1](https://setuptools.readthedocs.io/en/latest/deprecated/distutils/setupscript.html?highlight=license#additional-meta-data)

In addition add the appropriate license classifier from the [PyPI list of classifiers](https://pypi.org/classifiers/)