### PR TITLE
Release/1.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,17 @@
 History
 -------
 
+1.2.0 (2021-08-10)
+++++++++++++++++++
+
+* Bug fixes
+    - `GH#48 <https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/48>`_ and `GH#50 <https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/50>`_ issues: recognize the `~` tilde character as home directory alias
+    - `GH#36 <https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/36>`_, `GH#44 <https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/44>`_ and `GH#53 <https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/53>`_ issues: add missing test resource files to PyPI package
+    - `GH#41 <https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/41>`_: require PyOpenSSL >= v19.0.0 to avoid old OS packages
+
+* Improvements
+    - better Python 2 and Python 3 documentation and related setup.py tags
+
 1.1.0 (2017-09-11)
 ++++++++++++++++++
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE requirements.txt akamai/edgegrid/test/testdata.json
+include README.rst LICENSE requirements.txt akamai/edgegrid/test/testdata.json akamai/edgegrid/test/sample_edgerc akamai/edgegrid/test/edgerc_that_doesnt_parse

--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,8 @@ For Python 3.3 or newer, replace the `virtualenv` module with `venv`. Run:
 Creating your own .edgerc
 ----------
 
-#. Copy the `akamai/edgegrid/test/sample_edgerc` file to your home directory and rename as .edgerc.
-#. Edit the copied file and provide your own credentials. For more information on creating an .edgerc file, see `Get started  with APIs`_.
+#. Copy the `akamai/edgegrid/test/sample_edgerc` file to your home directory and rename as `.edgerc`.
+#. Edit the copied file and provide your own credentials. For more information on creating an `.edgerc` file, see `Get started  with APIs`_.
 
 .. _`Get started  with APIs`: https://developer.akamai.com/api/getting-started#edgercfile
 

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,14 @@ For Python 3.3 or newer, replace the `virtualenv` module with `venv`. Run:
     $ pip install -r requirements.txt
     $ python -m unittest discover
 
+Creating your own .edgerc
+----------
+
+#. Copy the `akamai/edgegrid/test/sample_edgerc` file to your home directory and rename as .edgerc.
+#. Edit the copied file and provide your own credentials. For more information on creating an .edgerc file, see `Get started  with APIs`_.
+
+.. _`Get started  with APIs`: https://developer.akamai.com/api/getting-started#edgercfile
+
 Contribute
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ visit the `Akamai {OPEN} Developer Community`_.
 
     >>> import requests
     >>> from akamai.edgegrid import EdgeGridAuth
-    >>> from urlparse import urljoin
+    >>> from urllib.parse import urljoin
     >>> baseurl = 'https://akaa-WWWWWWWWWWWW.luna.akamaiapis.net/'
     >>> s = requests.Session()
     >>> s.auth = EdgeGridAuth(
@@ -54,31 +54,50 @@ Alternatively, your program can read the credentials from an .edgerc file.
 Installation
 ------------
 
-Pre-requisite
--------------
-If you are installing on a Linux based distribution, you will need to install the developer libraries for python, ssl and a ffi. On Ubuntu based systems, you will need to do the following:
+**Prerequisite**
+
+For Linux-based distribution, install the developer libraries for Python, SSL and FFI. For example, on Debian-based systems, run:
 
 .. code-block:: bash
-    $ sudo apt-get install ibssl-dev libffi-dev python-dev 
 
+    $ sudo apt-get install ibssl-dev libffi-dev python-dev
 
-To install from pip:
+**To install from pip**
+
+If you are planning to use Python 2, upgrade pip to version 20.3.4, which is the most recent and last version that supports Python 2. Run:"
+
+.. code-block:: bash
+
+	$ pip install --upgrade 'pip<21.0'
+
+To proceed with the installation:
 
 .. code-block:: bash
 
     $ pip install edgegrid-python
 
-To install from sources:
+**To install from sources**
 
 .. code-block:: bash
 
     $ python setup.py install
 
-To run tests:
+**To run tests**
+
+Both Python 2 and Python 3 are supported. This example uses Python 2.7. Run:
 
 .. code-block:: bash
 
     $ virtualenv -p python2.7 venv
+    $ . venv/bin/activate
+    $ pip install -r requirements.txt
+    $ python -m unittest discover
+
+For Python 3.3 or newer, replace the `virtualenv` module with `venv`. Run:
+
+.. code-block:: bash
+
+    $ python3 -m venv venv
     $ . venv/bin/activate
     $ pip install -r requirements.txt
     $ python -m unittest discover

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Alternatively, your program can read the credentials from an .edgerc file.
 
     >>> import requests
     >>> from akamai.edgegrid import EdgeGridAuth, EdgeRc
-    >>> from urlparse import urljoin
+    >>> from urllib.parse import urljoin
 
     >>> edgerc = EdgeRc('~/.edgerc')
     >>> section = 'default'
@@ -46,6 +46,12 @@ Alternatively, your program can read the credentials from an .edgerc file.
     >>> result.json()['locations'][0]['value']
     Oakbrook, IL, United States
     ...
+
+If you intend to run the above examples with Python 2.7, remember that urljoin is contained in a different package:
+
+.. code-block:: pycon
+
+    >>> from urlparse import urljoin
 
 .. _`requests`: http://docs.python-requests.org
 .. _`Akamai {OPEN} Edgegrid authentication`: https://developer.akamai.com/introduction/Client_Auth.html

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Jonathan Landis
 License
 -------
 
-   Copyright 2015 Akamai Technologies, Inc. All rights reserved. 
+   Copyright 2021 Akamai Technologies, Inc. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/akamai/edgegrid/__init__.py
+++ b/akamai/edgegrid/__init__.py
@@ -37,6 +37,7 @@ __all__ = ['EdgeGridAuth', 'EdgeRc']
 __title__ = 'edgegrid-python'
 __version__ = '1.1'
 __author__ = 'Jonathan Landis <jlandis@akamai.com>'
+__maintainer__ = 'Akamai Developer Experience team <dl-devexp-eng@akamai.com>'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2021 Akamai Technologies'
 

--- a/akamai/edgegrid/__init__.py
+++ b/akamai/edgegrid/__init__.py
@@ -2,8 +2,8 @@
 akamai.edgegrid
 ~~~~~~~~~~~~~~~
 
-This library provides an authentication handler for Requests that implements the 
-Akamai {OPEN} EdgeGrid client authentication protocol as 
+This library provides an authentication handler for Requests that implements the
+Akamai {OPEN} EdgeGrid client authentication protocol as
 specified by https://developer.akamai.com/introduction/Client_Auth.html.
 For more information visit https://developer.akamai.com.
 
@@ -32,16 +32,16 @@ usage:
 
 from .edgegrid import EdgeGridAuth
 from .edgerc import EdgeRc
-__all__=['EdgeGridAuth', 'EdgeRc']
+__all__ = ['EdgeGridAuth', 'EdgeRc']
 
 __title__ = 'edgegrid-python'
 __version__ = '1.1'
 __author__ = 'Jonathan Landis <jlandis@akamai.com>'
 __license__ = 'Apache 2.0'
-__copyright__ = 'Copyright 2014 Akamai Technologies'
+__copyright__ = 'Copyright 2021 Akamai Technologies'
 
-# Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-# 
+# Copyright 2021 Akamai Technologies, Inc. All Rights Reserved
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -6,8 +6,8 @@
 #
 # For more information visit https://developer.akamai.com
 
-# Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-# 
+# Copyright 2021 Akamai Technologies, Inc. All Rights Reserved
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,7 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests
 import logging
 import uuid
 import hashlib
@@ -34,32 +33,40 @@ from time import gmtime, strftime
 
 if sys.version_info[0] >= 3:
     # python3
-    from urllib.parse import urlparse, parse_qsl, urlunparse
+    from urllib.parse import urlparse
 else:
     # python2.7
-    from urlparse import urlparse, parse_qsl, urlunparse
+    from urlparse import urlparse
     import urllib3.contrib.pyopenssl
     urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 logger = logging.getLogger(__name__)
 
-__all__=['EdgeGridAuth']
+__all__ = ['EdgeGridAuth']
+
 
 def eg_timestamp():
     return strftime('%Y%m%dT%H:%M:%S+0000', gmtime())
 
+
 def new_nonce():
     return uuid.uuid4()
 
+
 def base64_hmac_sha256(data, key):
     return base64.b64encode(
-        hmac.new(key.encode('utf8'), data.encode('utf8'), hashlib.sha256).digest()
+        hmac.new(
+            key.encode('utf8'),
+            data.encode('utf8'),
+            hashlib.sha256).digest()
     ).decode('utf8')
+
 
 def base64_sha256(data):
     if isinstance(data, str):
         data = data.encode('utf8')
     return base64.b64encode(hashlib.sha256(data).digest()).decode('utf8')
+
 
 class EdgeGridAuth(AuthBase):
     """A Requests authentication handler that provides Akamai {OPEN} EdgeGrid support.
@@ -76,15 +83,15 @@ class EdgeGridAuth(AuthBase):
 
     """
 
-    def __init__(self, client_token, client_secret, access_token, 
+    def __init__(self, client_token, client_secret, access_token,
                  headers_to_sign=None, max_body=131072):
-        """Initialize authentication using the given parameters from the Luna Manage APIs
+        """Initialize authentication using the given parameters from the Akamai OPEN APIs
            Interface:
 
         :param client_token: Client token provided by "Credentials" ui
         :param client_secret: Client secret provided by "Credentials" ui
         :param access_token: Access token provided by "Authorizations" ui
-        :param headers_to_sign: An ordered list header names that will be included in 
+        :param headers_to_sign: An ordered list header names that will be included in
             the signature.  This will be provided by specific APIs. (default [])
         :param max_body: Maximum content body size for POST requests. This will be provided by
             specific APIs. (default 131072)
@@ -94,7 +101,7 @@ class EdgeGridAuth(AuthBase):
         self.client_secret = client_secret
         self.access_token = access_token
         if headers_to_sign:
-            self.headers_to_sign = [ h.lower() for h in headers_to_sign ]
+            self.headers_to_sign = [h.lower() for h in headers_to_sign]
         else:
             self.headers_to_sign = []
         self.max_body = max_body
@@ -103,15 +110,15 @@ class EdgeGridAuth(AuthBase):
 
     @staticmethod
     def from_edgerc(rcinput, section='default'):
-        """Returns an EdgeGridAuth object from the configuration from the given section of the 
+        """Returns an EdgeGridAuth object from the configuration from the given section of the
            given edgerc file.
 
-        :param filename: path to the edgerc file
-        :param section: the section to use (this is the [bracketed] part of the edgerc, 
+        :param rcinput: EdgeRc instance or path to the edgerc file
+        :param section: the section to use (this is the [bracketed] part of the edgerc,
             default is 'default')
 
         """
-        from .edgerc import EdgeRc 
+        from .edgerc import EdgeRc
         if isinstance(rcinput, EdgeRc):
             rc = rcinput
         else:
@@ -149,11 +156,13 @@ class EdgeGridAuth(AuthBase):
             logger.debug("signing content: %s", prepared_body)
             if len(prepared_body) > self.max_body:
                 logger.debug(
-                    "data length %d is larger than maximum %d", 
+                    "data length %d is larger than maximum %d",
                     len(prepared_body), self.max_body
                 )
                 prepared_body = prepared_body[0:self.max_body]
-                logger.debug("data truncated to %d for computing the hash", len(prepared_body))
+                logger.debug(
+                    "data truncated to %d for computing the hash",
+                    len(prepared_body))
 
             content_hash = base64_sha256(prepared_body)
 
@@ -173,7 +182,8 @@ class EdgeGridAuth(AuthBase):
         akamai_cli_command = os.getenv('AKAMAI_CLI_COMMAND')
         akamai_cli_command_version = os.getenv('AKAMAI_CLI_COMMAND_VERSION')
         if akamai_cli_command and akamai_cli_command_version:
-            version_header += " AkamaiCLI-" + akamai_cli_command + "/" + akamai_cli_command_version
+            version_header += " AkamaiCLI-" + akamai_cli_command + \
+                "/" + akamai_cli_command_version
 
         if version_header != '':
             if 'User-Agent' not in header:
@@ -186,7 +196,7 @@ class EdgeGridAuth(AuthBase):
     def make_data_to_sign(self, r, auth_header):
         parsed_url = urlparse(r.url)
 
-        if (r.headers.get('Host', False)):
+        if r.headers.get('Host', False):
             netloc = r.headers['Host']
         else:
             netloc = parsed_url.netloc
@@ -197,8 +207,10 @@ class EdgeGridAuth(AuthBase):
             r.method,
             parsed_url.scheme,
             netloc,
-            # Note: relative URL constraints are handled by requests when it sets up 'r'
-            parsed_url.path + ('?' + parsed_url.query if parsed_url.query else ""),
+            # Note: relative URL constraints are handled by requests when it
+            # sets up 'r'
+            parsed_url.path + \
+            ('?' + parsed_url.query if parsed_url.query else ""),
             self.canonicalize_headers(r),
             self.make_content_hash(r),
             auth_header
@@ -208,7 +220,7 @@ class EdgeGridAuth(AuthBase):
 
     def sign_request(self, r, timestamp, auth_header):
         return base64_hmac_sha256(
-            self.make_data_to_sign(r, auth_header), 
+            self.make_data_to_sign(r, auth_header),
             self.make_signing_key(timestamp)
         )
 
@@ -219,7 +231,8 @@ class EdgeGridAuth(AuthBase):
             ('timestamp', timestamp),
             ('nonce', nonce),
         ]
-        auth_header = "EG1-HMAC-SHA256 " + ';'.join([ "%s=%s" % kvp for kvp in kvps ]) + ';'
+        auth_header = "EG1-HMAC-SHA256 " + \
+            ';'.join(["%s=%s" % kvp for kvp in kvps]) + ';'
         logger.debug('unsigned authorization header: %s', auth_header)
 
         signed_auth_header = auth_header + \

--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -3,6 +3,7 @@
 # EdgeGrid requests Auth handler
 #
 # Original author: Jonathan Landis <jlandis@akamai.com>
+# Package maintainer: Akamai Developer Experience team <dl-devexp-eng@akamai.com>
 #
 # For more information visit https://developer.akamai.com
 

--- a/akamai/edgegrid/edgerc.py
+++ b/akamai/edgegrid/edgerc.py
@@ -2,8 +2,8 @@
 #
 # support for .edgerc file format
 #
-# Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-# 
+# Copyright 2021 Akamai Technologies, Inc. All Rights Reserved
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -30,9 +30,16 @@ else:
 
 logger = logging.getLogger(__name__)
 
+
 class EdgeRc(ConfigParser):
     def __init__(self, filename):
-        ConfigParser.__init__(self, {'client_token': '', 'client_secret':'', 'host':'', 'access_token':'','max_body': '131072', 'headers_to_sign': 'None'})
+        ConfigParser.__init__(self,
+                              {'client_token': '',
+                               'client_secret': '',
+                               'host': '',
+                               'access_token': '',
+                               'max_body': '131072',
+                               'headers_to_sign': 'None'})
         logger.debug("loading edgerc from %s", filename)
 
         self.read(expanduser(filename))

--- a/akamai/edgegrid/edgerc.py
+++ b/akamai/edgegrid/edgerc.py
@@ -18,6 +18,7 @@
 
 import logging
 import sys
+from os.path import expanduser
 
 if sys.version_info[0] >= 3:
     # python3
@@ -34,7 +35,7 @@ class EdgeRc(ConfigParser):
         ConfigParser.__init__(self, {'client_token': '', 'client_secret':'', 'host':'', 'access_token':'','max_body': '131072', 'headers_to_sign': 'None'})
         logger.debug("loading edgerc from %s", filename)
 
-        self.read(filename)
+        self.read(expanduser(filename))
 
         logger.debug("successfully loaded edgerc")
 

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -125,14 +125,14 @@ class EGSimpleTest(unittest.TestCase):
         self.assertEqual(auth.client_secret, 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=')
         self.assertEqual(auth.access_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
         self.assertEqual(auth.max_body, 131072)
-        self.assertEqual(auth.headers_to_sign, [])
+        self.assertEqual(auth.headers_to_sign, ['none'])
 
     def test_edgerc_broken(self):
         auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'), 'broken')
         self.assertEqual(auth.client_secret, 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=')
         self.assertEqual(auth.access_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
         self.assertEqual(auth.max_body, 128*1024)
-        self.assertEqual(auth.headers_to_sign, [])
+        self.assertEqual(auth.headers_to_sign, ['none'])
 
     def test_edgerc_unparseable(self):
         try:
@@ -158,14 +158,18 @@ class EGSimpleTest(unittest.TestCase):
 
         header = auth.get_header_versions()
         self.assertTrue('User-Agent' in header)
-        self.assertEqual(header['User-Agent'], ' AkamaiCLI/1.0.0')
+        self.assertEqual(header['User-Agent'], 'AkamaiCLI/1.0.0')
+
+        header = auth.get_header_versions({'User-Agent': 'test-agent'})
+        self.assertTrue('User-Agent' in header)
+        self.assertEqual(header['User-Agent'], 'test-agent AkamaiCLI/1.0.0')
 
         os.environ["AKAMAI_CLI_COMMAND"] = '1.0.0'
         os.environ["AKAMAI_CLI_COMMAND_VERSION"] = '1.0.0'
 
         header = auth.get_header_versions()
         self.assertTrue('User-Agent' in header)
-        self.assertEqual(header['User-Agent'], ' AkamaiCLI/1.0.0 AkamaiCLI-1.0.0/1.0.0')
+        self.assertEqual(header['User-Agent'], 'AkamaiCLI/1.0.0 AkamaiCLI-1.0.0/1.0.0')
 
         header = auth.get_header_versions({'User-Agent': 'testvalue'})
         self.assertTrue('User-Agent' in header)
@@ -187,7 +191,7 @@ class EGSimpleTest(unittest.TestCase):
         self.assertEqual(auth.client_secret, 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=')
         self.assertEqual(auth.access_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
         self.assertEqual(auth.max_body, 131072)
-        self.assertEqual(auth.headers_to_sign, [])
+        self.assertEqual(auth.headers_to_sign, ['none'])
 
     def test_edgerc_dashes(self):
         auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'), 'dashes')

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -5,8 +5,8 @@
 #
 # For more information visit https://developer.akamai.com
 
-# Copyright 2014 Akamai Technologies, Inc. All Rights Reserved
-# 
+# Copyright 2021 Akamai Technologies, Inc. All Rights Reserved
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -19,13 +19,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import akamai.edgegrid.edgegrid as eg
+from akamai.edgegrid import EdgeGridAuth, EdgeRc
 import json
 import logging
 import os
 import re
 import requests
 import sys
-import traceback
 import unittest
 
 PY_VER = sys.version_info[0]
@@ -36,11 +37,12 @@ else:
     # python2.7
     from urlparse import urljoin
 
-from akamai.edgegrid import EdgeGridAuth, EdgeRc
-import akamai.edgegrid.edgegrid as eg
 
-mydir=os.path.abspath(os.path.dirname(__file__))
+mydir = os.path.abspath(os.path.dirname(__file__))
 logger = logging.getLogger(__name__)
+
+expected_client_secret = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx='
+
 
 class EdgeGridTest(unittest.TestCase):
     def __init__(self, testdata=None, testcase=None):
@@ -48,7 +50,7 @@ class EdgeGridTest(unittest.TestCase):
         self.testdata = testdata
         self.testcase = testcase
         self.maxDiff = None
-        
+
     def runTest(self):
         auth = EdgeGridAuth(
             client_token=self.testdata['client_token'],
@@ -58,23 +60,26 @@ class EdgeGridTest(unittest.TestCase):
             max_body=self.testdata['max_body']
         )
 
-        headers = { }
+        headers = {}
         if 'headers' in self.testcase['request']:
             for h in self.testcase['request']['headers']:
-                for k,v in h.items():
+                for k, v in h.items():
                     headers[k] = v
 
         request = requests.Request(
             method=self.testcase['request']['method'],
-            url=urljoin(self.testdata['base_url'],self.testcase['request']['path']),   
+            url=urljoin(
+                self.testdata['base_url'],
+                self.testcase['request']['path']),
             headers=headers,
-            data=self.testcase['request'].get('data') if self.testcase['request'].get('data') \
-                                                      else None
+            data=self.testcase['request'].get('data') if self.testcase['request'].get('data')
+            else None
         )
 
         try:
             auth_header = auth.make_auth_header(
-                request.prepare(), self.testdata['timestamp'], self.testdata['nonce']
+                request.prepare(
+                ), self.testdata['timestamp'], self.testdata['nonce']
             )
         except Exception as e:
             logger.debug('Got exception from make_auth_header', exc_info=True)
@@ -82,6 +87,7 @@ class EdgeGridTest(unittest.TestCase):
             return
 
         self.assertEqual(auth_header, self.testcase['expectedAuthorization'])
+
 
 class EGSimpleTest(unittest.TestCase):
     def test_nonce(self):
@@ -98,7 +104,7 @@ class EGSimpleTest(unittest.TestCase):
             \d{4} # year
             [0-1][0-9] # month
             [0-3][0-9] # day
-            T     
+            T
             [0-2][0-9] # hour
             :
             [0-5][0-9] # minute
@@ -121,38 +127,55 @@ class EGSimpleTest(unittest.TestCase):
 
     def test_edgerc_default(self):
         auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'))
-        self.assertEqual(auth.client_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
-        self.assertEqual(auth.client_secret, 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=')
-        self.assertEqual(auth.access_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
+        self.assertEqual(
+            auth.client_token,
+            'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
+        self.assertEqual(
+            auth.client_secret,
+            expected_client_secret)
+        self.assertEqual(
+            auth.access_token,
+            'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
         self.assertEqual(auth.max_body, 131072)
         self.assertEqual(auth.headers_to_sign, ['none'])
 
     def test_edgerc_broken(self):
-        auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'), 'broken')
-        self.assertEqual(auth.client_secret, 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=')
-        self.assertEqual(auth.access_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
-        self.assertEqual(auth.max_body, 128*1024)
+        auth = EdgeGridAuth.from_edgerc(
+            os.path.join(mydir, 'sample_edgerc'), 'broken')
+        self.assertEqual(
+            auth.client_secret,
+            expected_client_secret)
+        self.assertEqual(
+            auth.access_token,
+            'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
+        self.assertEqual(auth.max_body, 128 * 1024)
         self.assertEqual(auth.headers_to_sign, ['none'])
 
     def test_edgerc_unparseable(self):
+        # noinspection PyBroadException
         try:
-            auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'edgerc_that_doesnt_parse'))
+            EdgeGridAuth.from_edgerc(
+                os.path.join(mydir, 'edgerc_that_doesnt_parse'))
             self.fail("should have thrown an exception")
-        except:
+        except BaseException:
             pass
 
     def test_edgerc_headers(self):
-        auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'), 'headers')
+        auth = EdgeGridAuth.from_edgerc(
+            os.path.join(mydir, 'sample_edgerc'), 'headers')
         self.assertEqual(auth.headers_to_sign, ['x-mything1', 'x-mything2'])
 
     def test_get_header_versions(self):
-        auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'), 'headers')
+        auth = EdgeGridAuth.from_edgerc(
+            os.path.join(mydir, 'sample_edgerc'), 'headers')
         header = auth.get_header_versions()
         self.assertFalse('user-agent' in header)
 
         header = auth.get_header_versions({'User-Agent': 'testvalue'})
         self.assertTrue('User-Agent' in header)
 
+        # setting environment variables with hardcoded `1.0.0` value, just for this test.
+        # These variables are cleared at the end of this test.
         os.environ["AKAMAI_CLI"] = '1.0.0'
         os.environ["AKAMAI_CLI_VERSION"] = '1.0.0'
 
@@ -169,11 +192,14 @@ class EGSimpleTest(unittest.TestCase):
 
         header = auth.get_header_versions()
         self.assertTrue('User-Agent' in header)
-        self.assertEqual(header['User-Agent'], 'AkamaiCLI/1.0.0 AkamaiCLI-1.0.0/1.0.0')
+        self.assertEqual(header['User-Agent'],
+                         'AkamaiCLI/1.0.0 AkamaiCLI-1.0.0/1.0.0')
 
         header = auth.get_header_versions({'User-Agent': 'testvalue'})
         self.assertTrue('User-Agent' in header)
-        self.assertEqual(header['User-Agent'], 'testvalue AkamaiCLI/1.0.0 AkamaiCLI-1.0.0/1.0.0')
+        self.assertEqual(
+            header['User-Agent'],
+            'testvalue AkamaiCLI/1.0.0 AkamaiCLI-1.0.0/1.0.0')
 
         del os.environ['AKAMAI_CLI']
         del os.environ['AKAMAI_CLI_VERSION']
@@ -186,16 +212,24 @@ class EGSimpleTest(unittest.TestCase):
         self.assertFalse('AKAMAI_CLI_COMMAND_VERSION' in os.environ)
 
     def test_edgerc_from_object(self):
-        auth = EdgeGridAuth.from_edgerc(EdgeRc(os.path.join(mydir, 'sample_edgerc')))
-        self.assertEqual(auth.client_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
-        self.assertEqual(auth.client_secret, 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=')
-        self.assertEqual(auth.access_token, 'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
+        auth = EdgeGridAuth.from_edgerc(
+            EdgeRc(os.path.join(mydir, 'sample_edgerc')))
+        self.assertEqual(
+            auth.client_token,
+            'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
+        self.assertEqual(
+            auth.client_secret,
+            expected_client_secret)
+        self.assertEqual(
+            auth.access_token,
+            'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
         self.assertEqual(auth.max_body, 131072)
         self.assertEqual(auth.headers_to_sign, ['none'])
 
     def test_edgerc_dashes(self):
-        auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'), 'dashes')
-        self.assertEqual(auth.max_body, 128*1024)
+        auth = EdgeGridAuth.from_edgerc(
+            os.path.join(mydir, 'sample_edgerc'), 'dashes')
+        self.assertEqual(auth.max_body, 128 * 1024)
 
 
 class JsonTest(unittest.TestCase):
@@ -217,18 +251,19 @@ class JsonTest(unittest.TestCase):
         }
 
         data = {
-            'key':'value',
+            'key': 'value',
         }
 
         request = requests.Request(
             method='POST',
-            url=urljoin(self.testdata['base_url'],'/testapi/v1/t3'),
+            url=urljoin(self.testdata['base_url'], '/testapi/v1/t3'),
             params=params,
             json=data,
         )
 
         auth_header = auth.make_auth_header(
-            request.prepare(), self.testdata['timestamp'], self.testdata['nonce']
+            request.prepare(
+            ), self.testdata['timestamp'], self.testdata['nonce']
         )
 
         self.assertEqual(auth_header, self.testdata['jsontest_hash'])
@@ -259,9 +294,10 @@ def suite():
 
     return suite
 
+
 def load_tests(loader=None, tests=None, pattern=None):
     return suite()
 
+
 if __name__ == '__main__':
     runner = unittest.TextTestRunner().run(suite())
-

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -2,6 +2,7 @@
 # unit tests for edgegrid. runs tests from testdata.json
 #
 # Original author: Jonathan Landis <jlandis@akamai.com>
+# Package maintainer: Akamai Developer Experience team <dl-devexp-eng@akamai.com>
 #
 # For more information visit https://developer.akamai.com
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.3.0
-pyopenssl
+pyopenssl>=19.0.0
 ndg-httpsclient
 pyasn1
 urllib3

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ setup(
     description='{OPEN} client authentication protocol for python-requests',
     author='Jonathan Landis',
     author_email='jlandis@akamai.com',
+    maintainer='Akamai Developer Experience team',
+    maintainer_email='dl-devexp-eng@akamai.com',
     url='https://github.com/akamai-open/AkamaiOPEN-edgegrid-python',
     namespace_packages=['akamai'],
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,17 @@ setup(
     namespace_packages=['akamai'],
     packages=find_packages(),
     python_requires=">=2.7.10",
-    install_requires = [
+    install_requires=[
         'requests>=2.3.0',
-        'pyOpenSSL >= 0.13',
+        'pyOpenSSL>=19.0.0',
         'ndg-httpsclient',
         'pyasn1',
         'urllib3'
     ],
-    license='LICENSE.txt'
+    license='Apache 2.0',
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+    ]
 )


### PR DESCRIPTION
## 1.2.0 (2021-08-10)

### Bug fixes
 * [GH#48](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/48) and [GH#50](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/50) issues: recognize the `~` tilde character as home directory alias
 * [GH#36](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/36), [GH#44](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/44) and [GH#53](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/53) issues: add missing test resource files to PyPI package
 * [GH#41](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/41): require PyOpenSSL >= v19.0.0 to avoid old OS packages

### Improvements
 * better Python 2 and Python 3 documentation and related setup.py tags