### PR TITLE
release/1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, find_packages
 setup(
     name='edgegrid-python', 
-    version='1.1.1', 
+    version='1.2.0', 
     description='{OPEN} client authentication protocol for python-requests',
     author='Jonathan Landis',
     author_email='jlandis@akamai.com',
     maintainer='Akamai Developer Experience team',
     maintainer_email='dl-devexp-eng@akamai.com',
-    url='https://github.com/akamai-open/AkamaiOPEN-edgegrid-python',
+    url='https://github.com/akamai/AkamaiOPEN-edgegrid-python',
     namespace_packages=['akamai'],
     packages=find_packages(),
     python_requires=">=2.7.10",


### PR DESCRIPTION
## 1.2.0 (2021-08-10)

### Bug fixes
 * [GH#48](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/48) and [GH#50](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/50) issues: recognize the `~` tilde character as home directory alias
 * [GH#36](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/36), [GH#44](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/44) and [GH#53](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/53) issues: add missing test resource files to PyPI package
 * [GH#41](https://github.com/akamai/AkamaiOPEN-edgegrid-python/issues/41): require PyOpenSSL >= v19.0.0 to avoid old OS packages
 * update release version and repository in `setup.py`.

### Improvements
 * better Python 2 and Python 3 documentation and related setup.py tags