### PR TITLE
Decoupled code from requests library

### DIFF
--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -138,22 +138,22 @@ class EdgeGridAuth(AuthBase):
         logger.debug('signing key: %s', signing_key)
         return signing_key
 
-    def canonicalize_headers(self, r):
+    def canonicalize_headers(self, headers):
         spaces_re = re.compile('\\s+')
 
         # note: r.headers is a case-insensitive dict and self.headers_to_sign
         # should already be lowercased at this point
         return '\t'.join([
-            "%s:%s" % (h, spaces_re.sub(' ', r.headers[h].strip()))
-            for h in self.headers_to_sign if h in r.headers
+            "%s:%s" % (h, spaces_re.sub(' ', headers[h].strip()))
+            for h in self.headers_to_sign if h in headers
         ])
 
-    def make_content_hash(self, r):
+    def make_content_hash(self, body, method):
         content_hash = ""
-        prepared_body = (r.body or '')
+        prepared_body = body
         logger.debug("body is '%s'", prepared_body)
 
-        if r.method == 'POST' and len(prepared_body) > 0:
+        if method == 'POST' and len(prepared_body) > 0:
             logger.debug("signing content: %s", prepared_body)
             if len(prepared_body) > self.max_body:
                 logger.debug(
@@ -194,38 +194,38 @@ class EdgeGridAuth(AuthBase):
 
         return header
 
-    def make_data_to_sign(self, r, auth_header):
-        parsed_url = urlparse(r.url)
+    def make_data_to_sign(self, url, headers, auth_header, method, body):
+        parsed_url = urlparse(url)
 
-        if r.headers.get('Host', False):
-            netloc = r.headers['Host']
+        if headers.get('Host', False):
+            netloc = headers['Host']
         else:
             netloc = parsed_url.netloc
 
-        self.get_header_versions(r.headers)
+        self.get_header_versions(headers)
 
         data_to_sign = '\t'.join([
-            r.method,
+            method,
             parsed_url.scheme,
             netloc,
             # Note: relative URL constraints are handled by requests when it
             # sets up 'r'
             parsed_url.path + \
             ('?' + parsed_url.query if parsed_url.query else ""),
-            self.canonicalize_headers(r),
-            self.make_content_hash(r),
+            self.canonicalize_headers(headers),
+            self.make_content_hash(body or '', method),
             auth_header
         ])
         logger.debug('data to sign: %s', '\\t'.join(data_to_sign.split('\t')))
         return data_to_sign
 
-    def sign_request(self, r, timestamp, auth_header):
+    def sign_request(self, url, headers, method, body, timestamp, auth_header):
         return base64_hmac_sha256(
-            self.make_data_to_sign(r, auth_header),
+            self.make_data_to_sign(url, headers, auth_header, method, body),
             self.make_signing_key(timestamp)
         )
 
-    def make_auth_header(self, r, timestamp, nonce):
+    def make_auth_header(self, url, headers, method, body, timestamp, nonce):
         kvps = [
             ('client_token', self.client_token),
             ('access_token', self.access_token),
@@ -237,7 +237,7 @@ class EdgeGridAuth(AuthBase):
         logger.debug('unsigned authorization header: %s', auth_header)
 
         signed_auth_header = auth_header + \
-            'signature=' + self.sign_request(r, timestamp, auth_header)
+            'signature=' + self.sign_request(url, headers, method, body, timestamp, auth_header)
 
         logger.debug('signed authorization header: %s', signed_auth_header)
         return signed_auth_header
@@ -251,13 +251,25 @@ class EdgeGridAuth(AuthBase):
             request_to_sign.url = redirect_location
 
             res.request.headers['Authorization'] = self.make_auth_header(
-                request_to_sign, eg_timestamp(), new_nonce()
+                request_to_sign.url,
+                request_to_sign.headers,
+                request_to_sign.method,
+                request_to_sign.body,
+                eg_timestamp(),
+                new_nonce()
             )
 
     def __call__(self, r):
         timestamp = eg_timestamp()
         nonce = new_nonce()
 
-        r.headers['Authorization'] = self.make_auth_header(r, timestamp, nonce)
+        r.headers['Authorization'] = self.make_auth_header(
+            r.url,
+            r.headers,
+            r.method,
+            r.body,
+            timestamp,
+            nonce
+        )
         r.register_hook('response', self.handle_redirect)
         return r

--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -69,7 +69,7 @@ def base64_sha256(data):
     return base64.b64encode(hashlib.sha256(data).digest()).decode('utf8')
 
 
-class AuthHeaders():
+class EdgeGridAuthHeaders():
 
     def __init__(self, client_token, client_secret, access_token,
                  headers_to_sign=None, max_body=131072):
@@ -222,7 +222,7 @@ class EdgeGridAuth(AuthBase):
             specific APIs. (default 131072)
 
         """
-        self.ah = AuthHeaders(
+        self.ah = EdgeGridAuthHeaders(
             client_token,
             client_secret,
             access_token,

--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -69,35 +69,10 @@ def base64_sha256(data):
     return base64.b64encode(hashlib.sha256(data).digest()).decode('utf8')
 
 
-class EdgeGridAuth(AuthBase):
-    """A Requests authentication handler that provides Akamai {OPEN} EdgeGrid support.
-
-    Basic Usage::
-        >>> import requests
-        >>> from akamai.edgegrid import EdgeGridAuth
-        >>> s = requests.Session()
-        >>> s.auth = EdgeGridAuth(
-            client_token='cccccccccccccccccc',
-            client_secret='sssssssssssssssss',
-            access_token='aaaaaaaaaaaaaaaaa'
-        )
-
-    """
+class AuthHeaders():
 
     def __init__(self, client_token, client_secret, access_token,
                  headers_to_sign=None, max_body=131072):
-        """Initialize authentication using the given parameters from the Akamai OPEN APIs
-           Interface:
-
-        :param client_token: Client token provided by "Credentials" ui
-        :param client_secret: Client secret provided by "Credentials" ui
-        :param access_token: Access token provided by "Authorizations" ui
-        :param headers_to_sign: An ordered list header names that will be included in
-            the signature.  This will be provided by specific APIs. (default [])
-        :param max_body: Maximum content body size for POST requests. This will be provided by
-            specific APIs. (default 131072)
-
-        """
         self.client_token = client_token
         self.client_secret = client_secret
         self.access_token = access_token
@@ -106,32 +81,6 @@ class EdgeGridAuth(AuthBase):
         else:
             self.headers_to_sign = []
         self.max_body = max_body
-
-        self.redirect_location = None
-
-    @staticmethod
-    def from_edgerc(rcinput, section='default'):
-        """Returns an EdgeGridAuth object from the configuration from the given section of the
-           given edgerc file.
-
-        :param rcinput: EdgeRc instance or path to the edgerc file
-        :param section: the section to use (this is the [bracketed] part of the edgerc,
-            default is 'default')
-
-        """
-        from .edgerc import EdgeRc
-        if isinstance(rcinput, EdgeRc):
-            rc = rcinput
-        else:
-            rc = EdgeRc(rcinput)
-
-        return EdgeGridAuth(
-            client_token=rc.get(section, 'client_token'),
-            client_secret=rc.get(section, 'client_secret'),
-            access_token=rc.get(section, 'access_token'),
-            headers_to_sign=rc.getlist(section, 'headers_to_sign'),
-            max_body=rc.getint(section, 'max_body')
-        )
 
     def make_signing_key(self, timestamp):
         signing_key = base64_hmac_sha256(timestamp, self.client_secret)
@@ -242,6 +191,69 @@ class EdgeGridAuth(AuthBase):
         logger.debug('signed authorization header: %s', signed_auth_header)
         return signed_auth_header
 
+
+
+class EdgeGridAuth(AuthBase):
+    """A Requests authentication handler that provides Akamai {OPEN} EdgeGrid support.
+
+    Basic Usage::
+        >>> import requests
+        >>> from akamai.edgegrid import EdgeGridAuth
+        >>> s = requests.Session()
+        >>> s.auth = EdgeGridAuth(
+            client_token='cccccccccccccccccc',
+            client_secret='sssssssssssssssss',
+            access_token='aaaaaaaaaaaaaaaaa'
+        )
+
+    """
+
+    def __init__(self, client_token, client_secret, access_token,
+                 headers_to_sign=None, max_body=131072):
+        """Initialize authentication using the given parameters from the Akamai OPEN APIs
+           Interface:
+
+        :param client_token: Client token provided by "Credentials" ui
+        :param client_secret: Client secret provided by "Credentials" ui
+        :param access_token: Access token provided by "Authorizations" ui
+        :param headers_to_sign: An ordered list header names that will be included in
+            the signature.  This will be provided by specific APIs. (default [])
+        :param max_body: Maximum content body size for POST requests. This will be provided by
+            specific APIs. (default 131072)
+
+        """
+        self.ah = AuthHeaders(
+            client_token,
+            client_secret,
+            access_token,
+            headers_to_sign,
+            max_body
+        )
+
+    @staticmethod
+    def from_edgerc(rcinput, section='default'):
+        """Returns an EdgeGridAuth object from the configuration from the given section of the
+           given edgerc file.
+
+        :param rcinput: EdgeRc instance or path to the edgerc file
+        :param section: the section to use (this is the [bracketed] part of the edgerc,
+            default is 'default')
+
+        """
+        from .edgerc import EdgeRc
+        if isinstance(rcinput, EdgeRc):
+            rc = rcinput
+        else:
+            rc = EdgeRc(rcinput)
+
+        return EdgeGridAuth(
+            client_token=rc.get(section, 'client_token'),
+            client_secret=rc.get(section, 'client_secret'),
+            access_token=rc.get(section, 'access_token'),
+            headers_to_sign=rc.getlist(section, 'headers_to_sign'),
+            max_body=rc.getint(section, 'max_body')
+        )
+
     def handle_redirect(self, res, **kwargs):
         if res.is_redirect:
             redirect_location = res.headers['location']
@@ -250,7 +262,7 @@ class EdgeGridAuth(AuthBase):
             request_to_sign = res.request.copy()
             request_to_sign.url = redirect_location
 
-            res.request.headers['Authorization'] = self.make_auth_header(
+            res.request.headers['Authorization'] = self.ah.make_auth_header(
                 request_to_sign.url,
                 request_to_sign.headers,
                 request_to_sign.method,
@@ -263,7 +275,7 @@ class EdgeGridAuth(AuthBase):
         timestamp = eg_timestamp()
         nonce = new_nonce()
 
-        r.headers['Authorization'] = self.make_auth_header(
+        r.headers['Authorization'] = self.ah.make_auth_header(
             r.url,
             r.headers,
             r.method,

--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -85,7 +85,7 @@ class EdgeGridAuth(AuthBase):
     """
 
     def __init__(self, client_token, client_secret, access_token,
-                 headers_to_sign=None, max_body=131072):
+                 headers_to_sign=(), max_body=131072):
         """Initialize authentication using the given parameters from the Akamai OPEN APIs
            Interface:
 
@@ -167,14 +167,11 @@ class EdgeGridAuth(AuthBase):
 class EdgeGridAuthHeaders():
 
     def __init__(self, client_token, client_secret, access_token,
-                 headers_to_sign=None, max_body=131072):
+                 headers_to_sign=(), max_body=131072):
         self.client_token = client_token
         self.client_secret = client_secret
         self.access_token = access_token
-        if headers_to_sign:
-            self.headers_to_sign = [h.lower() for h in headers_to_sign]
-        else:
-            self.headers_to_sign = []
+        self.headers_to_sign = [h.lower() for h in headers_to_sign]
         self.max_body = max_body
 
     def make_signing_key(self, timestamp):

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -78,9 +78,11 @@ class EdgeGridTest(unittest.TestCase):
         )
 
         try:
+            r = request.prepare(
+                )
             auth_header = auth.make_auth_header(
-                request.prepare(
-                ), self.testdata['timestamp'], self.testdata['nonce']
+                r.url, r.headers, r.method, r.body, self.testdata['timestamp'],
+                self.testdata['nonce']
             )
         except Exception as e:
             logger.debug('Got exception from make_auth_header', exc_info=True)
@@ -262,9 +264,10 @@ class JsonTest(unittest.TestCase):
             json=data,
         )
 
+        r = request.prepare()
         auth_header = auth.make_auth_header(
-            request.prepare(
-            ), self.testdata['timestamp'], self.testdata['nonce']
+            r.url, r.headers, r.method, r.body, self.testdata['timestamp'],
+            self.testdata['nonce']
         )
 
         self.assertEqual(auth_header, self.testdata['jsontest_hash'])

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -107,8 +107,7 @@ class EdgeGridTest(unittest.TestCase):
         )
 
         try:
-            r = request.prepare(
-                )
+            r = request.prepare()
             auth_header = auth.ah.make_auth_header(
                 r.url, r.headers, r.method, r.body, self.testdata['timestamp'],
                 self.testdata['nonce']

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -80,7 +80,7 @@ class EdgeGridTest(unittest.TestCase):
         try:
             r = request.prepare(
                 )
-            auth_header = auth.make_auth_header(
+            auth_header = auth.ah.make_auth_header(
                 r.url, r.headers, r.method, r.body, self.testdata['timestamp'],
                 self.testdata['nonce']
             )
@@ -125,34 +125,34 @@ class EGSimpleTest(unittest.TestCase):
         auth = EdgeGridAuth(
             client_token='xxx', client_secret='xxx', access_token='xxx'
         )
-        self.assertEqual(auth.max_body, 131072)
-        self.assertEqual(auth.headers_to_sign, [])
+        self.assertEqual(auth.ah.max_body, 131072)
+        self.assertEqual(auth.ah.headers_to_sign, [])
 
     def test_edgerc_default(self):
         auth = EdgeGridAuth.from_edgerc(os.path.join(mydir, 'sample_edgerc'))
         self.assertEqual(
-            auth.client_token,
+            auth.ah.client_token,
             'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
         self.assertEqual(
-            auth.client_secret,
+            auth.ah.client_secret,
             expected_client_secret)
         self.assertEqual(
-            auth.access_token,
+            auth.ah.access_token,
             'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
-        self.assertEqual(auth.max_body, 131072)
-        self.assertEqual(auth.headers_to_sign, ['none'])
+        self.assertEqual(auth.ah.max_body, 131072)
+        self.assertEqual(auth.ah.headers_to_sign, ['none'])
 
     def test_edgerc_broken(self):
         auth = EdgeGridAuth.from_edgerc(
             os.path.join(mydir, 'sample_edgerc'), 'broken')
         self.assertEqual(
-            auth.client_secret,
+            auth.ah.client_secret,
             expected_client_secret)
         self.assertEqual(
-            auth.access_token,
+            auth.ah.access_token,
             'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
-        self.assertEqual(auth.max_body, 128 * 1024)
-        self.assertEqual(auth.headers_to_sign, ['none'])
+        self.assertEqual(auth.ah.max_body, 128 * 1024)
+        self.assertEqual(auth.ah.headers_to_sign, ['none'])
 
     def test_edgerc_unparseable(self):
         # noinspection PyBroadException
@@ -166,15 +166,15 @@ class EGSimpleTest(unittest.TestCase):
     def test_edgerc_headers(self):
         auth = EdgeGridAuth.from_edgerc(
             os.path.join(mydir, 'sample_edgerc'), 'headers')
-        self.assertEqual(auth.headers_to_sign, ['x-mything1', 'x-mything2'])
+        self.assertEqual(auth.ah.headers_to_sign, ['x-mything1', 'x-mything2'])
 
     def test_get_header_versions(self):
         auth = EdgeGridAuth.from_edgerc(
             os.path.join(mydir, 'sample_edgerc'), 'headers')
-        header = auth.get_header_versions()
+        header = auth.ah.get_header_versions()
         self.assertFalse('user-agent' in header)
 
-        header = auth.get_header_versions({'User-Agent': 'testvalue'})
+        header = auth.ah.get_header_versions({'User-Agent': 'testvalue'})
         self.assertTrue('User-Agent' in header)
 
         # setting environment variables with hardcoded `1.0.0` value, just for this test.
@@ -182,23 +182,23 @@ class EGSimpleTest(unittest.TestCase):
         os.environ["AKAMAI_CLI"] = '1.0.0'
         os.environ["AKAMAI_CLI_VERSION"] = '1.0.0'
 
-        header = auth.get_header_versions()
+        header = auth.ah.get_header_versions()
         self.assertTrue('User-Agent' in header)
         self.assertEqual(header['User-Agent'], 'AkamaiCLI/1.0.0')
 
-        header = auth.get_header_versions({'User-Agent': 'test-agent'})
+        header = auth.ah.get_header_versions({'User-Agent': 'test-agent'})
         self.assertTrue('User-Agent' in header)
         self.assertEqual(header['User-Agent'], 'test-agent AkamaiCLI/1.0.0')
 
         os.environ["AKAMAI_CLI_COMMAND"] = '1.0.0'
         os.environ["AKAMAI_CLI_COMMAND_VERSION"] = '1.0.0'
 
-        header = auth.get_header_versions()
+        header = auth.ah.get_header_versions()
         self.assertTrue('User-Agent' in header)
         self.assertEqual(header['User-Agent'],
                          'AkamaiCLI/1.0.0 AkamaiCLI-1.0.0/1.0.0')
 
-        header = auth.get_header_versions({'User-Agent': 'testvalue'})
+        header = auth.ah.get_header_versions({'User-Agent': 'testvalue'})
         self.assertTrue('User-Agent' in header)
         self.assertEqual(
             header['User-Agent'],
@@ -218,21 +218,21 @@ class EGSimpleTest(unittest.TestCase):
         auth = EdgeGridAuth.from_edgerc(
             EdgeRc(os.path.join(mydir, 'sample_edgerc')))
         self.assertEqual(
-            auth.client_token,
+            auth.ah.client_token,
             'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
         self.assertEqual(
-            auth.client_secret,
+            auth.ah.client_secret,
             expected_client_secret)
         self.assertEqual(
-            auth.access_token,
+            auth.ah.access_token,
             'xxxx-xxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxx')
-        self.assertEqual(auth.max_body, 131072)
-        self.assertEqual(auth.headers_to_sign, ['none'])
+        self.assertEqual(auth.ah.max_body, 131072)
+        self.assertEqual(auth.ah.headers_to_sign, ['none'])
 
     def test_edgerc_dashes(self):
         auth = EdgeGridAuth.from_edgerc(
             os.path.join(mydir, 'sample_edgerc'), 'dashes')
-        self.assertEqual(auth.max_body, 128 * 1024)
+        self.assertEqual(auth.ah.max_body, 128 * 1024)
 
 
 class JsonTest(unittest.TestCase):
@@ -265,7 +265,7 @@ class JsonTest(unittest.TestCase):
         )
 
         r = request.prepare()
-        auth_header = auth.make_auth_header(
+        auth_header = auth.ah.make_auth_header(
             r.url, r.headers, r.method, r.body, self.testdata['timestamp'],
             self.testdata['nonce']
         )

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -45,15 +45,15 @@ logger = logging.getLogger(__name__)
 expected_client_secret = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx='
 
 
-class AuthHeadersTest(unittest.TestCase):
+class EdgeGridAuthHeadersTest(unittest.TestCase):
     def __init__(self, testdata=None, testcase=None):
-        super(AuthHeadersTest, self).__init__()
+        super(EdgeGridAuthHeadersTest, self).__init__()
         self.testdata = testdata
         self.testcase = testcase
         self.maxDiff = None
 
     def runTest(self):
-        self.ah = eg.AuthHeaders(
+        self.ah = eg.EdgeGridAuthHeaders(
             client_token=self.testdata['client_token'],
             client_secret=self.testdata['client_secret'],
             access_token=self.testdata['access_token'],
@@ -312,7 +312,7 @@ def suite():
 
     for test in tests:
         suite.addTest(EdgeGridTest(testdata, test))
-        suite.addTest(AuthHeadersTest(testdata, test))
+        suite.addTest(EdgeGridAuthHeadersTest(testdata, test))
 
     suite.addTest(JsonTest(testdata))
 

--- a/akamai/edgegrid/test/test_edgegrid.py
+++ b/akamai/edgegrid/test/test_edgegrid.py
@@ -45,6 +45,35 @@ logger = logging.getLogger(__name__)
 expected_client_secret = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx='
 
 
+class AuthHeadersTest(unittest.TestCase):
+    def __init__(self, testdata=None, testcase=None):
+        super(AuthHeadersTest, self).__init__()
+        self.testdata = testdata
+        self.testcase = testcase
+        self.maxDiff = None
+
+    def runTest(self):
+        self.ah = eg.AuthHeaders(
+            client_token=self.testdata['client_token'],
+            client_secret=self.testdata['client_secret'],
+            access_token=self.testdata['access_token'],
+            headers_to_sign=self.testdata['headers_to_sign'],
+            max_body=self.testdata['max_body']
+        )
+
+        sign_key = self.ah.make_signing_key(self.testdata['timestamp'])
+        self.assertEqual(sign_key, self.testdata["sign_key_test"])
+
+        content_hash = self.ah.make_content_hash(
+            body="test_body",
+            method="POST"
+        )
+        self.assertEqual(content_hash, self.testdata["content_hash_test"])
+
+        header = self.ah.get_header_versions()
+        self.assertEqual(header, {})
+
+
 class EdgeGridTest(unittest.TestCase):
     def __init__(self, testdata=None, testcase=None):
         super(EdgeGridTest, self).__init__()
@@ -283,6 +312,7 @@ def suite():
 
     for test in tests:
         suite.addTest(EdgeGridTest(testdata, test))
+        suite.addTest(AuthHeadersTest(testdata, test))
 
     suite.addTest(JsonTest(testdata))
 

--- a/akamai/edgegrid/test/testdata.json
+++ b/akamai/edgegrid/test/testdata.json
@@ -8,6 +8,8 @@
     "nonce": "nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     "timestamp": "20140321T19:34:21+0000",
     "jsontest_hash": "EG1-HMAC-SHA256 client_token=akab-client-token-xxx-xxxxxxxxxxxxxxxx;access_token=akab-access-token-xxx-xxxxxxxxxxxxxxxx;timestamp=20140321T19:34:21+0000;nonce=nonce-xx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;signature=nONuDe50qGrPius4Rg4D2jfi/2zDZWAYRUG6RudJLNM=",
+    "sign_key_test": "znsRMDBRqTXGJ7Ojip3/h2FGPu3LuoMYWgv9PKEnE/o=",
+    "content_hash_test": "REPGqEEubBHzJMhwqDZtbt515/ntEvAMNriNR53zcdY=",
     "tests": [
         {
             "testName": "simple GET",


### PR DESCRIPTION
This PR makes it possible to use the client with any http library. Even an async one like `aiohttp`. 

For this change we had to untangle the code a bit. Tests have been provided.

Happy to answer any questions.