### PR TITLE
Include testcases.json in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include LICENSE
 include requirements.txt
+include akamai/edgegrid/test/testcases.json
 include akamai/edgegrid/test/testdata.json
 include akamai/edgegrid/test/sample_edgerc
 include akamai/edgegrid/test/edgerc_that_doesnt_parse


### PR DESCRIPTION
Attempting to run the tests from the current sdist on PyPI fails because testcases.json is missing.