### PR TITLE
Include sample_file.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include requirements.txt
 include akamai/edgegrid/test/testcases.json
 include akamai/edgegrid/test/testdata.json
 include akamai/edgegrid/test/sample_edgerc
+include akamai/edgegrid/test/sample_file.txt
 include akamai/edgegrid/test/edgerc_that_doesnt_parse


### PR DESCRIPTION
Attempting to run the tests from the current sdist on PyPI fails because sample_file.txt is missing.