### PR TITLE
Add cast for urlparse 

### DIFF
--- a/akamai/edgegrid/edgegrid.py
+++ b/akamai/edgegrid/edgegrid.py
@@ -276,7 +276,7 @@ class EdgeGridAuthHeaders:
         return header
 
     def make_data_to_sign(self, request, auth_header):
-        parsed_url = urlparse(request.url)
+        parsed_url = urlparse(str(request.url))
 
         if request.headers.get('Host', False):
             netloc = request.headers['Host']


### PR DESCRIPTION
Client libraries like httpx assume request.url are typed with internal models.

Casting it to str make others library comptatible with urllib