### PR TITLE
Setuptools 82 compatibility

### DIFF
--- a/akamai/__init__.py
+++ b/akamai/__init__.py
@@ -1,2 +1,0 @@
-"""Library provides an authentication handler for requests"""
-__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
+
 
 setup(
     name='edgegrid-python',
     version='2.0.5',
     description='{OPEN} client authentication protocol for python-requests',
     url='https://github.com/akamai/AkamaiOPEN-edgegrid-python',
-    namespace_packages=['akamai'],
-    packages=find_packages(),
+    packages=find_namespace_packages(),
     python_requires=">=3.10",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
pkg_resources has been deprecated since setuptools 67.5.0, and is removed in setuptools 82.0.0.  Instead, we can rely on PEP 420 and find_namespace_packages to handle the namespace.

https://setuptools.pypa.io/en/stable/history.html#v82-0-0
https://setuptools.pypa.io/en/stable/userguide/package_discovery.html#finding-namespace-packages